### PR TITLE
ProxyFactory address refactoring from createCompanyWallet method

### DIFF
--- a/lib/helper/User.js
+++ b/lib/helper/User.js
@@ -312,7 +312,6 @@ class User {
    * Method for creation and configuration of token holder proxy contract for company
    * with hardware wallet as it's owner.
    *
-   * @param proxyFactory proxyFactory contract address.
    * @param owner TokenHolder proxy owner address. It could be hardware wallet address.
    * @param sessionKeys Session key addresses to authorize.
    * @param sessionKeysSpendingLimits Session key's spending limits.
@@ -320,18 +319,10 @@ class User {
    *
    * @returns Promise object.
    */
-  async createCompanyWallet(
-    proxyFactory,
-    owner,
-    sessionKeys,
-    sessionKeysSpendingLimits,
-    sessionKeysExpirationHeights,
-    txOptions
-  ) {
+  async createCompanyWallet(owner, sessionKeys, sessionKeysSpendingLimits, sessionKeysExpirationHeights, txOptions) {
     const oThis = this;
 
     const txObject = oThis._createCompanyWalletRawTx(
-      proxyFactory,
       owner,
       sessionKeys,
       sessionKeysSpendingLimits,
@@ -399,7 +390,6 @@ class User {
    * Private method used for creation and configuration of token holder proxy contract for company
    * with hardware wallet as it's owner.
    *
-   * @param proxyFactory proxyFactory contract address.
    * @param owner TokenHolder proxy owner address. It could be hardware wallet address.
    * @param sessionKeys Session key addresses to authorize.
    * @param sessionKeysSpendingLimits Session key's spending limits.
@@ -407,7 +397,7 @@ class User {
    *
    * @returns Promise object.
    */
-  _createCompanyWalletRawTx(proxyFactory, owner, sessionKeys, sessionKeysSpendingLimits, sessionKeysExpirationHeights) {
+  _createCompanyWalletRawTx(owner, sessionKeys, sessionKeysSpendingLimits, sessionKeysExpirationHeights) {
     const oThis = this;
 
     const thSetupExecutableData = oThis.getTokenHolderSetupExecutableData(
@@ -419,7 +409,7 @@ class User {
 
     const jsonInterface = oThis.abiBinProvider.getABI(ProxyFactoryContractName);
 
-    const contract = new oThis.auxiliaryWeb3.eth.Contract(jsonInterface, proxyFactory);
+    const contract = new oThis.auxiliaryWeb3.eth.Contract(jsonInterface, oThis.proxyFactory);
 
     return contract.methods.createProxy(oThis.tokenHolderMasterCopy, thSetupExecutableData);
   }

--- a/test/integration/DirectTransfer.js
+++ b/test/integration/DirectTransfer.js
@@ -311,7 +311,7 @@ describe('Direct transfers between TH contracts', async function() {
       mockToken,
       tokenRulesAddress,
       userWalletFactoryAddress,
-      null, // proxy factory address
+      proxyFactoryAddress, // proxy factory address
       auxiliaryWeb3
     );
 
@@ -321,7 +321,6 @@ describe('Direct transfers between TH contracts', async function() {
     const sessionKeys = [sessionKey];
 
     const response = await userInstance.createCompanyWallet(
-      proxyFactoryAddress,
       thMasterCopyAddress,
       sessionKeys,
       [config.sessionKeySpendingLimit],


### PR DESCRIPTION
Anything common to any user/company should go into constructor, and we should only pass as an argument things that differs for user/company.
ProxyFactory is already being passed in User.js constructor. createCompanyWallet method can read from class state.