### PR TITLE
Recovery Interact Fixes

### DIFF
--- a/lib/ContractInteract/Recovery.js
+++ b/lib/ContractInteract/Recovery.js
@@ -396,8 +396,8 @@ class Recovery {
 
     const typedDataInput = {
       types: {
-        EIP712Domain: [{ name: 'verifyingContract', type: 'address' }],
-        SafeTx: [
+        EIP712Domain: [{ name: 'delayedRecoveryModule', type: 'address' }],
+        InitiateRecoveryStruct: [
           { name: 'prevOwner', type: 'address' },
           { name: 'oldOwner', type: 'address' },
           { name: 'newOwner', type: 'address' }
@@ -405,7 +405,7 @@ class Recovery {
       },
       primaryType: 'InitiateRecoveryStruct',
       domain: {
-        verifyingContract: this.delayedRecoveryAddress
+        delayedRecoveryModule: this.delayedRecoveryAddress
       },
       message: {
         prevOwner: prevOwner,
@@ -449,8 +449,8 @@ class Recovery {
 
     const typedDataInput = {
       types: {
-        EIP712Domain: [{ name: 'verifyingContract', type: 'address' }],
-        SafeTx: [
+        EIP712Domain: [{ name: 'delayedRecoveryModule', type: 'address' }],
+        InitiateRecoveryStruct: [
           { name: 'prevOwner', type: 'address' },
           { name: 'oldOwner', type: 'address' },
           { name: 'newOwner', type: 'address' }
@@ -458,7 +458,7 @@ class Recovery {
       },
       primaryType: 'AbortRecoveryStruct',
       domain: {
-        verifyingContract: this.delayedRecoveryAddress
+        delayedRecoveryModule: this.delayedRecoveryAddress
       },
       message: {
         prevOwner: prevOwner,
@@ -497,12 +497,15 @@ class Recovery {
 
     const typedDataInput = {
       types: {
-        EIP712Domain: [{ name: 'verifyingContract', type: 'address' }],
-        SafeTx: [{ name: 'oldRecoveryOwner', type: 'address' }, { name: 'newRecoveryOwner', type: 'address' }]
+        EIP712Domain: [{ name: 'delayedRecoveryModule', type: 'address' }],
+        InitiateRecoveryStruct: [
+          { name: 'oldRecoveryOwner', type: 'address' },
+          { name: 'newRecoveryOwner', type: 'address' }
+        ]
       },
       primaryType: 'ResetRecoveryOwnerStruct',
       domain: {
-        verifyingContract: this.delayedRecoveryAddress
+        delayedRecoveryModule: this.delayedRecoveryAddress
       },
       message: {
         oldRecoveryOwner: oldRecoveryOwner,


### PR DESCRIPTION
PR covers few fixes while integration with recovery:

- primaryType mismatch fix.

- As per EIP712 domainSeparator, signing domain for address should be 
```
  bytes32 public constant DOMAIN_SEPARATOR_TYPEHASH = keccak256(
        "EIP712Domain(address  verifyingContract)"
    );
```
  Gnosis also follows same domain signing field name:
    https://github.com/gnosis/safe-contracts/blob/development/contracts/GnosisSafe.sol
 ```
keccak256(
        "EIP712Domain(address verifyingContract)"
    );
```

 - However for recovery DOMAIN_SEPARATOR_TYPEHASH is below:
```
bytes32 public constant DOMAIN_SEPARATOR_TYPEHASH = keccak256(
        "EIP712Domain(address delayedRecoveryModule)"
    );
```


